### PR TITLE
Update TwigTag to make it compatible with TemplateTag

### DIFF
--- a/src/Tag/TwigTag.php
+++ b/src/Tag/TwigTag.php
@@ -6,7 +6,7 @@ namespace Setono\TagBag\Tag;
 
 class TwigTag extends TemplateTag implements TwigTagInterface
 {
-    protected $name = 'setono_tag_bag_twig_tag';
+    protected string $name = 'setono_tag_bag_twig_tag';
 
     /**
      * @param mixed $value


### PR DESCRIPTION
Update TwigTag to make it compatible again with TemplateTag. See https://github.com/Setono/SyliusTagBagPlugin/issues/12.